### PR TITLE
Changed compare_ssim -> structural_similarity

### DIFF
--- a/src/glund/tools.py
+++ b/src/glund/tools.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 from scipy import linalg
-from skimage.measure import compare_ssim as ssim
+from skimage.metrics import structural_similarity as ssim
 from sklearn.base import TransformerMixin, BaseEstimator
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils import check_array, as_float_array


### PR DESCRIPTION
The `measure.compare_ssim` function from `scikit-image` is now removed moved to `metrics.structural_similarity`. See [0.16 changelog](https://scikit-image.org/docs/0.16.x/api_changes.html#version-0-16).

For the usage it has in the code, I think this change might be enough (they keywords seem to have changed but they are not used). For reference: [old docs](https://scikit-image.org/docs/0.12.x/api/skimage.measure.html#skimage.measure.compare_ssim) - [new docs](https://scikit-image.org/docs/dev/api/skimage.metrics.html#skimage.metrics.structural_similarity)
